### PR TITLE
Change a little bit the PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,28 @@
-* **Please check if the PR fulfills these requirements** (please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)
+**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
 - [ ] The commit message follows our guidelines
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 
-* **Does this PR already have an issue describing the problem ?** If so, link to this issue using `'#XXX'` and skip the rest
-
-
-* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
+**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
 
 
 
-* **What is the current behavior?** (You can also link to an open issue here)
+**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
 
 
 
-* **What is the new behavior (if this is a feature change)?**
+**What is the current behavior?** *(You can also link to an open issue here)*
 
 
 
-* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
+**What is the new behavior (if this is a feature change)?**
 
 
 
-* **Other information**:
+**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*
+
+
+
+**Other information**:
 
 (if any of the questions/checkboxes don't apply, please delete them entirely)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements** (please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)
- [x] The commit message follows our guidelines

* **Does this PR already have an issue describing the problem ?** If so, link to this issue using `'#XXX'` and skip the rest

N/A

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Contributing

* **What is the current behavior?** (You can also link to an open issue here)

There are bullets before the questions asked by this template but sometimes it's not really readable (see [powsybl-core#710](https://github.com/powsybl/powsybl-core/pull/710)). In this example the list of in the description is followed by the first question of the template

> This is an example:
> - item 1
> - item 2
> 
> * **Please check if the PR fulfills these requirements** (please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)
> ...

* **What is the new behavior (if this is a feature change)?**
With this new version of the template, there is no bullet anymore:
> This is an example:
> - item 1
> - item 2
> 
> **Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
> ...


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

I also put the helping messages in italic



* **Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
