### PR TITLE
Fix/add organization readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,3 @@
-![PowSyBl Logo](images/powsybl.svg?sanitize=true)
+# .github
 
-PowSyBl (**Pow**er **Sy**stem **Bl**ocks) is an open source framework written in Java, dedicated to electrical grid modelling and simulation. The power system blocks may be used through scripts for a quick shot, but also be assembled to build state of the art applications.
-
-PowSyBl is part of the [LF Energy Foundation](https://www.lfenergy.org), a project of The Linux Foundation that supports open source innovation projects within the energy and electricity sectors.
-
-One major aim of the project is to make it easy to write complex software for power system simulation and analysis.
-
-For example, using PowSyBl one can create applications able to:
-- handle a variety of formats, such as CGMES for European data exchanges
-- perform power flow simulations and security analyses on the network
-- perform dynamic simulations on the network
-
-Another key characteristic of PowSyBl is its modular design, at the core of the open source approach. It enables developers to extend or customize its features by providing their own plugins.
-
-On [PowSyBl website](https://www.powsybl.org), you will have access to a complete [overview](https://www.powsybl.org/pages/overview/) of the project, its [governance](https://www.powsybl.org/pages/overview/governance) and [roadmap](https://www.powsybl.org/pages/overview/roadmap).
-
-You will also find the [user and developer documentation](https://www.powsybl.org/pages/documentation/) to help you to start working with PowSyBl. We hope you will find it great, and help us to make it better by [contributing](https://www.powsybl.org/pages/contributing/) to the project. 
+*Community health files for the [@PowSyBl](https://github.com/powsybl) organization*

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,18 @@
+![PowSyBl Logo](images/powsybl.svg?sanitize=true)
+
+PowSyBl (**Pow**er **Sy**stem **Bl**ocks) is an open source framework written in Java, dedicated to electrical grid modelling and simulation. The power system blocks may be used through scripts for a quick shot, but also be assembled to build state of the art applications.
+
+PowSyBl is part of the [LF Energy Foundation](https://www.lfenergy.org), a project of The Linux Foundation that supports open source innovation projects within the energy and electricity sectors.
+
+One major aim of the project is to make it easy to write complex software for power system simulation and analysis.
+
+For example, using PowSyBl one can create applications able to:
+- handle a variety of formats, such as CGMES for European data exchanges
+- perform power flow simulations and security analyses on the network
+- perform dynamic simulations on the network
+
+Another key characteristic of PowSyBl is its modular design, at the core of the open source approach. It enables developers to extend or customize its features by providing their own plugins.
+
+On [PowSyBl website](https://www.powsybl.org), you will have access to a complete [overview](https://www.powsybl.org/pages/overview/) of the project, its [governance](https://www.powsybl.org/pages/overview/governance) and [roadmap](https://www.powsybl.org/pages/overview/roadmap).
+
+You will also find the [user and developer documentation](https://www.powsybl.org/pages/documentation/) to help you to start working with PowSyBl. We hope you will find it great, and help us to make it better by [contributing](https://www.powsybl.org/pages/contributing/) to the project. 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem ?** 
No


**What kind of change does this PR introduce?**
fix/feature


**What is the current behavior?**
The current README.md seems to be for the organization profile but is not in the profile folder


**What is the new behavior (if this is a feature change)?**
README.md moved to the profile folder and new very basic README.md added for this repo


**Other information**:
See the documentation for organization profile [here](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile) and an example [here](https://github.com/github/.github/tree/master/profile which is displayed on github [organization home page](https://github.com/github/).
A private version for members only could also be added.