### PR TITLE
Specify released repositories in case of a patch release

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,7 @@ In order to help you assess the severity of the potential vulnerability, you can
 If you are not sure whether the issue should be reported privately or publicly, please make a private report.
 
 After reporting a potential vulnerability, you will be contacted by a PowSyBl team member within 7 calendar days. If the report proves to be a vulnerability, the library users will be informed and the vulnerability will be patched within 30 calendar days for critical or important vulnerabilities or in the next release train for moderate to low-severity vulnerabilities.
+
 For security patch releases (outside the release train), the **repositories concerned by the vulnerability** and the **powsybl-dependencies repository** will be released. The powsybl-starter and powsybl-distribution repositories will be released upon request only.
 
 ## When to report a vulnerability

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,6 +18,7 @@ In order to help you assess the severity of the potential vulnerability, you can
 If you are not sure whether the issue should be reported privately or publicly, please make a private report.
 
 After reporting a potential vulnerability, you will be contacted by a PowSyBl team member within 7 calendar days. If the report proves to be a vulnerability, the library users will be informed and the vulnerability will be patched within 30 calendar days for critical or important vulnerabilities or in the next release train for moderate to low-severity vulnerabilities.
+For security patch releases (outside the release train), the **repositories concerned by the vulnerability** and the **powsybl-dependencies repository** will be released. The powsybl-starter and powsybl-distribution repositories will be released upon request only.
 
 ## When to report a vulnerability
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines



**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
Documentation update
In case of a patch version, released to fix a vulnerability, only the repositories concerned by the vulnerability are released, as well as the powsybl-dependencies  repository. The powsybl-starter and powsybl-distribution repositories are released upon request only.



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
