### PR TITLE
Modify release strategy to include gpg signing - corrective releases

### DIFF
--- a/BRANCHING_RELEASE_STRATEGY.md
+++ b/BRANCHING_RELEASE_STRATEGY.md
@@ -214,11 +214,19 @@ $ git cherry-pick -x <commit2_hash>
 And bump to the patched version:
 ```shell
 $ mvn versions:set -DnewVersion=X.Y.Z
-$ git commit -s -m "Bump to vX.Y.Z"
+$ git commit -s -a -S -m "Bump to vX.Y.Z"
 $ git push -u origin release-vX.Y.0
 ```
 
-You can then create a Release note and tag via the GitHub UI, using directly the release branch. The tag must respect the pattern `vX.Y.Z`
+After that, create your tag:
+```shell
+$ git tag -s vX.Y.Z <hash of the corresponding commit (bumping to vX.Y.Z)>
+$ git push origin vX.Y.Z
+```
+NB: the tag must respect the pattern `vX.Y.Z`.
+
+You can then publish a Release note pointing to your newly created tag.
+
 Please make sure that your release note is comprehensive to all bug fixes of the corrective release.
 
 You shall then follow the steps described above in [Publishing a release](#publishing-a-release).


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update

**What is the current behavior?**
<!-- You can also link to an open issue here -->
In the release strategy, the commits and tags for corrective releases are **not** gpg signed.


**What is the new behavior (if this is a feature change)?**
In the release strategy, the commits and tags for corrective releases **are gpg signed**.
