### PR TITLE
Add missing '-a' options during commits in BRANCHING_RELEASE_STRATEGY.md

### DIFF
--- a/BRANCHING_RELEASE_STRATEGY.md
+++ b/BRANCHING_RELEASE_STRATEGY.md
@@ -145,7 +145,7 @@ $ git checkout -b tmp_prepare_release
 $ mvn versions:set -DnewVersion=X.Y.0
 $ git commit -s -a -S -m "Bump to vX.Y.0"
 $ mvn versions:set -DnewVersion=X.Y+1.0-SNAPSHOT
-$ git commit -s -m "Bump to vX.Y+1.0-SNAPSHOT"
+$ git commit -s -a -m "Bump to vX.Y+1.0-SNAPSHOT"
 $ git push -u origin tmp_prepare_release
 ```
 
@@ -203,7 +203,7 @@ $ git checkout release-vX.Y.0
 Next, open the new release:
 ```shell
 $ mvn versions:set -DnewVersion=X.Y.Z-SNAPSHOT
-$ git commit -s -m "Bump to vX.Y.Z-SNAPSHOT"
+$ git commit -s -a -m "Bump to vX.Y.Z-SNAPSHOT"
 ```
 
 You can then cherry-pick the commits of your patch:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In the release strategy doc, some `git commit` operations are performed without adding the corresponding files.


**What is the new behavior (if this is a feature change)?**
A `-a` option ("automatically stage files that have been modified") is added to these commit instructions.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
