### PR TITLE
Fixes in the release strategy documentation

### DIFF
--- a/BRANCHING_RELEASE_STRATEGY.md
+++ b/BRANCHING_RELEASE_STRATEGY.md
@@ -36,7 +36,7 @@ Other members must create a pull request to do push into these branches and pass
 
 ## Release cycle
 
-A new release train of the framework occurs roughly every two months.
+A new release train of the framework occurs roughly every two or three months.
 
 In case of structural issues, corrective releases can also be published for some repositories.
 These corrective releases are motivated by users' demand so don't hesitate to [contact us](https://www.powsybl.org/pages/community/).
@@ -61,7 +61,6 @@ Our release train consists in the release of:
 For each released repository:
 - a release note is written by one of the repository's committers
 - in case of breaking changes, a migration guide is written by one or several of the repository's developers
-- its latest version is updated on the [repositories' pages](https://www.powsybl.org/pages/documentation/developer/repositories/)
 - its latest version is updated in [powsybl-dependencies](https://github.com/powsybl/powsybl-dependencies)
 
 Once all the repositories have been released


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Doc fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
- Release strategy documentation contains a step referencing "the repositories' pages" which will be removed from the institutional website.
- The release train frequency is said to be "every two months".


**What is the new behavior (if this is a feature change)?**
- The step is removed.
- The release train frequency is fixed ("every two or three months").


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
