### PR TITLE
Make the procedure to request Committer rights more practical

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,10 +114,6 @@ Developers requesting Committer rights should keep the following points in mind:
 
 ### Procedure to Request Committer rights
 
-A pull request (PR) should be created for each person and each repository.  
-
-An exception can be made for individuals with special roles in the project (e.g., the release manager) who need to merge changes across multiple repositories (more than five). In such cases, a single PR may be submitted to maintain a practical process, but it must be thoroughly justified.
-
 The PR should be opened by the person requesting Committer rights.
 
 The PR must include a justification, which may be based on:  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,9 +124,9 @@ The PR must include a justification, which may be based on:
 
 ### Vote to Grant Committer Rights
 
-PowSyBl Committers can vote on adding a new Committer or expanding the rights of an existing Committer.
+PowSyBl Committers can vote on adding a new Committer or expanding the rights of an existing Committer.  
 
-If Committers are requesting additional rights (on other repositories), they should abstain from voting on their own requests.
+If Committers are requesting additional rights (on other repositories), they should abstain from voting on their own requests.  
 
 The poll will remain open for at least one week, during which time existing Committers will be notified and can vote "Yes" or "No."  
 A quorum (50% + 1 of the total number of Committers) is required for the vote to be valid.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines





**What kind of change does this PR introduce?**
This PR updates the procedure to ask for Committer rights (discussed at the December 5, 2024 TSC meeting).



**What is the current behavior?**
The developer was allowed to open a unique PR if they ask rights on more than 5 repositories.


**What is the new behavior (if this is a feature change)?**
There is no limit on the number of repositories. The number of PRs to open is at the discretion of the developer.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

