### PR TITLE
Split command bloc for the tmp_release_branch

### DIFF
--- a/BRANCHING_RELEASE_STRATEGY.md
+++ b/BRANCHING_RELEASE_STRATEGY.md
@@ -137,18 +137,26 @@ $ git checkout main
 $ git pull
 ```
 
-Create your temporary branch preparing to the release X.Y.0 and add commits bumping to your release version then your next snapshot version.
-You can then push this branch.
+Create your temporary branch preparing to the release X.Y.0 and add a commit bumping to your release version.
 ```shell
 $ git checkout -b tmp_prepare_release
 $ mvn versions:set -DnewVersion=X.Y.0
 $ git commit -s -a -S -m "Bump to vX.Y.0"
-$ mvn versions:set -DnewVersion=X.Y+1.0-SNAPSHOT
-$ git commit -s -a -S -m "Bump to vX.Y+1.0-SNAPSHOT"
 $ git push -u origin tmp_prepare_release
 ```
 
-Create a pull request from your temporary branch into the `main` branch and tag another maintainer as a reviewer so they can approve it.
+Create a pull request from your temporary branch into the `main` branch.
+Wait until all the CI criteria are fully validated. Then add a commit for your next snapshot version.
+You can then push again.
+
+```shell
+$ mvn versions:set -DnewVersion=X.Y+1.0-SNAPSHOT
+$ git commit -s -a -S -m "Bump to vX.Y+1.0-SNAPSHOT"
+$ git push
+```
+
+Tag another maintainer as a reviewer to your pull request so they can approve it.
+
 Once it is approved, locally merge it by following these steps:
 ```shell
 $ git checkout main


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
Documentation update.

The current procedure for the tmp_release_branch leads to: 
![image](https://github.com/user-attachments/assets/3558c60e-7318-4be5-ac72-56c2622c08f5)
The "Bump to vX.Y.Z" commit does not show CI checks.
This is a problem for rule-set based repositories (i.e. powsybl-diagram) but also for apps which grade repositories according to best development practices.

The change in the procedure is a way to ensure both commits of the tmp_release_branch show CI checks.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
