### PR TITLE
Add Alice Caron to committers for notebooks

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -76,7 +76,7 @@ This [repository](https://github.com/powsybl/pypowsybl) provides an GraalVM inte
 This [repository](https://github.com/powsybl/pypowsybl-notebooks) provides some notebooks using pypowsybl for demos and tutorials.
 
 **Reviewers:** [geofjamg](https://github.com/geofjamg), [colinepiloquet](https://github.com/colinepiloquet), [obrix](https://github.com/obrix)  
-**Committers:** [geofjamg](https://github.com/geofjamg), [obrix](https://github.com/obrix)
+**Committers:** [geofjamg](https://github.com/geofjamg), [obrix](https://github.com/obrix), [alicecaron](https://github.com/alicecaron)
 
 ### pypowsybl-jupyter
 


### PR DESCRIPTION
I am Alice Caron (https://github.com/alicecaron), I'm working at RTE in the PowSyBl team as product owner (former TechLead on other projects before that). I've been working on PowSyBl for half a year now, creating issues, reviewing merge requests and developing in powsybl-core and powsybl-open-loadflow repositories.

As a product owner I am in contact with PowSyBl users and need to show them features. Notebooks are a part of that.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)

**What kind of change does this PR introduce?**

Add alicecaron (Alice Caron) as a maintainer on the following repositories:
- pypowsybl-notebooks

