### PR TITLE
Add Hugo SCHINDLER to committers for entsoe

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -33,8 +33,8 @@ This [repository](https://github.com/powsybl/powsybl-dynawo) provides an impleme
 ### powsybl-entsoe [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-entsoe.svg?sort=semver)](https://github.com/powsybl/powsybl-entsoe/releases/)
 This [repository](https://github.com/powsybl/powsybl-entsoe) provides components specific to ENTSO-E-orientated processes.
 
-**Reviewers:** [phiedw](https://github.com/phiedw), [colinepiloquet](https://github.com/colinepiloquet)     
-**Committers:** [phiedw](https://github.com/phiedw)   
+**Reviewers:** [phiedw](https://github.com/phiedw), [colinepiloquet](https://github.com/colinepiloquet), [OpenSuze](https://github.com/OpenSuze)  
+**Committers:** [phiedw](https://github.com/phiedw), [OpenSuze](https://github.com/OpenSuze)  
 
 ### powsybl-open-rao [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-open-rao.svg?sort=semver)](https://github.com/powsybl/powsybl-open-rao/releases/)
 This [repository](https://github.com/powsybl/powsybl-open-rao) provides a modular engine for remedial actions optimization.


### PR DESCRIPTION
I am Hugo SCHINDLER (https://github.com/OpenSuze), I'm working at RTE in the software development department as developer.  
I've been working on PowSyBl for three years now, writting code on the flow decomposition, creating issues, reviewing merge requests and developing in the powsybl-entsoe repository mainly.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**What kind of change does this PR introduce?**
Add OpenSuze (Hugo SCHINDLER) as a committer and reviewer on the following repositories:
- pypowsybl-entsoe
