### PR TITLE
Update dependencies for readthedocs

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.12"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.13"
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -11,3 +11,4 @@ sphinx:
 python:
   install:
     - requirements: docs/requirements.txt
+    

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx==7.1.2
+sphinx==9.1.0
 sphinx-tabs
-furo==2024.1.29
-myst-parser
+furo==2025.12.19
+myst-parser>=4.0.0
 sphinx-copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ sphinx-tabs
 furo==2025.12.19
 myst-parser>=4.0.0
 sphinx-copybutton
+


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Dependency updates


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Documentation uses in .readthedocs.yaml:
- ubuntu 20.04
- python 3.9

In requirements:
- sphinx==7.1.2
- furo==2024.1.29
- myst-parser


**What is the new behavior (if this is a feature change)?**
Documentation uses in .readthedocs.yaml:
- ubuntu **24.04**
- python **3.12**

In requirements:
- sphinx==9.1.0
- furo==2025.12.19
- myst-parser>=4.0.0

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

Ubuntu 20.04 LTS will not be supported anymore by Readthedocs starting from June 2026 (see the [announcement](https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/)).