### PR TITLE
Add olperr1 as a reviewer/committer to .github and powsybl-parent

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -99,8 +99,8 @@ This [repository](https://github.com/powsybl/powsybl.jl) provides a GraalVM inte
 ### .github
 This [repository](https://github.com/powsybl/.github) contains documents to explain how the PowSyBl organization works (code of conduct, maintainers, contributing, security). It also provides the templates for the issues and the pull requests. These documents are shared by all the repositories. The associated Github wiki contains the roadmap of the whole organization.
 
-**Reviewers:** [So-Fras](https://github.com/So-Fras), [rolnico](https://github.com/rolnico)    
-**Committers:** [So-Fras](https://github.com/So-Fras), [rolnico](https://github.com/rolnico)
+**Reviewers:** [So-Fras](https://github.com/So-Fras), [rolnico](https://github.com/rolnico), [olperr1](https://github.com/olperr1)  
+**Committers:** [So-Fras](https://github.com/So-Fras), [rolnico](https://github.com/rolnico), [olperr1](https://github.com/olperr1)
 
 ### powsybl.github.io
 This [repository](https://github.com/powsybl/powsybl.github.io) contains the source code of the PowSyBl organizational website.
@@ -121,8 +121,8 @@ This [repository](https://github.com/powsybl/powsybl-tutorials) contains the sou
 ### powsybl-parent [![GitHub release](https://img.shields.io/github/release/powsybl/powsybl-parent.svg?sort=semver)](https://github.com/powsybl/powsybl-parent/releases/)
 This [repository](https://github.com/powsybl/powsybl-parent) provides the build configuration shared as maven pom files, shared by all our Java repositories.
 
-**Reviewers:** [jonenst](https://github.com/jonenst), [Tristan-WorkGH](https://github.com/Tristan), [TheMaskedTurtle](https://github.com/TheMaskedTurtle), [achour94](https://github.com/achour94), [antoinebhs](https://github.com/antoinebhs), [AbdelHedhili](https://github.com/AbdelHedhili), [rolnico](https://github.com/rolnico)  
-**Committers:** [jonenst](https://github.com/jonenst), [rolnico](https://github.com/rolnico)
+**Reviewers:** [jonenst](https://github.com/jonenst), [Tristan-WorkGH](https://github.com/Tristan), [TheMaskedTurtle](https://github.com/TheMaskedTurtle), [achour94](https://github.com/achour94), [antoinebhs](https://github.com/antoinebhs), [AbdelHedhili](https://github.com/AbdelHedhili), [rolnico](https://github.com/rolnico), [olperr1](https://github.com/olperr1)  
+**Committers:** [jonenst](https://github.com/jonenst), [rolnico](https://github.com/rolnico), [olperr1](https://github.com/olperr1)
 
 ### java-docker
 This [repository](https://github.com/powsybl/java-docker) provides a base docker image with java and a 'powsybl' user to be used by our deployments.  


### PR DESCRIPTION
Hi,
I am Olivier Perrin. I have been working at RTE as tech lead in the PowSyBl team for about 3 years. I am also PowSyBl's release manager. I have mainly contributed to powsybl-core, as a developer and reviewer/committer, and to the release-train-related repositories.

There are only 2 committers on the `powsyb-parent` and `.github` repositories. To help them and to facilitates merging, I would like to be added as a committer (and a reviewer) to these projects.

<br/>


**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update: 
Add olperr1 as a reviewer and committer on `powsybl-parent` and `.github`.
