### PR TITLE
Add HugoKulesza as reviewer and committer on pypowsybl-notebooks

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -75,7 +75,7 @@ This [repository](https://github.com/powsybl/pypowsybl) provides a GraalVM integ
 
 This [repository](https://github.com/powsybl/pypowsybl-notebooks) provides some notebooks using pypowsybl for demos and tutorials.
 
-**Reviewers:** [geofjamg](https://github.com/geofjamg), [colineplqt](https://github.com/colineplqt), [obrix](https://github.com/obrix), [HugoKulesza](https://github.com/HugoKulesza)
+**Reviewers:** [geofjamg](https://github.com/geofjamg), [colineplqt](https://github.com/colineplqt), [obrix](https://github.com/obrix), [HugoKulesza](https://github.com/HugoKulesza)  
 **Committers:** [geofjamg](https://github.com/geofjamg), [obrix](https://github.com/obrix), [alicecaron](https://github.com/alicecaron), [Godelaine](https://github.com/Godelaine), [HugoKulesza](https://github.com/HugoKulesza)
 
 ### pypowsybl-jupyter

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -75,8 +75,8 @@ This [repository](https://github.com/powsybl/pypowsybl) provides a GraalVM integ
 
 This [repository](https://github.com/powsybl/pypowsybl-notebooks) provides some notebooks using pypowsybl for demos and tutorials.
 
-**Reviewers:** [geofjamg](https://github.com/geofjamg), [colineplqt](https://github.com/colineplqt), [obrix](https://github.com/obrix)  
-**Committers:** [geofjamg](https://github.com/geofjamg), [obrix](https://github.com/obrix), [alicecaron](https://github.com/alicecaron), [Godelaine](https://github.com/Godelaine)
+**Reviewers:** [geofjamg](https://github.com/geofjamg), [colineplqt](https://github.com/colineplqt), [obrix](https://github.com/obrix), [HugoKulesza](https://github.com/HugoKulesza)
+**Committers:** [geofjamg](https://github.com/geofjamg), [obrix](https://github.com/obrix), [alicecaron](https://github.com/alicecaron), [Godelaine](https://github.com/Godelaine), [HugoKulesza](https://github.com/HugoKulesza)
 
 ### pypowsybl-jupyter
 


### PR DESCRIPTION
Hi, I'm Hugo Kulesza. I have been maintainer and release manager of `pyposwybl` for the last 2 years, while also contributing regularly to other repositories of the release train (e.g. core or OLF). 
In order to guarantee that the associated notebooks keep being functional with the regular releases, I need to be able to commit changes to the pypowsybl-notebooks repository.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Doc update : adding HugoKulesza as reviewer/committer on `pypowsybl-notebooks`
